### PR TITLE
[CHORE] remove go verion as it is unsupported

### DIFF
--- a/autogen_config.json
+++ b/autogen_config.json
@@ -11,6 +11,9 @@
             "key_vault_reference_identity_id",
             "zip_deploy_file"
         ],
+        "never_allow": [
+            "go_version"
+        ],
         "always_sensitive": [
             "app_settings",
             "site_config"

--- a/resource_impl.tf
+++ b/resource_impl.tf
@@ -295,7 +295,6 @@ resource "azurerm_linux_web_app" "this" {
         docker_registry_url      = var.site_config.application_stack.docker_registry_url
         docker_registry_username = var.site_config.application_stack.docker_registry_username
         dotnet_version           = var.site_config.application_stack.dotnet_version
-        go_version               = var.site_config.application_stack.go_version
         java_server              = var.site_config.application_stack.java_server
         java_server_version      = var.site_config.application_stack.java_server_version
         java_version             = var.site_config.application_stack.java_version

--- a/resource_variables.tf
+++ b/resource_variables.tf
@@ -325,7 +325,6 @@ variable "site_config" {
       docker_registry_url      = optional(string),
       docker_registry_username = optional(string),
       dotnet_version           = optional(string),
-      go_version               = optional(string),
       java_server              = optional(string),
       java_server_version      = optional(string),
       java_version             = optional(string),


### PR DESCRIPTION
Azure no longer supports golang for web apps, we should just not include it in our wrapper to indicate deprecation