### PR TITLE
[SVLS-9256] auto-mark DD_ENV as sticky when datadog_env is set

### DIFF
--- a/modules/linux/autogen_config.json
+++ b/modules/linux/autogen_config.json
@@ -6,7 +6,8 @@
     "fields": {
         "impl": [
             "app_settings",
-            "tags"
+            "tags",
+            "sticky_settings"
         ],
         "always_allow": [
             "key_vault_reference_identity_id",

--- a/modules/linux/main.tf
+++ b/modules/linux/main.tf
@@ -92,6 +92,13 @@ locals {
     var.datadog_version != null ? { version = var.datadog_version } : {},
     var.tags
   )
+  sticky_settings = var.datadog_env != null ? {
+    app_setting_names = distinct(concat(
+      coalesce(try(var.sticky_settings.app_setting_names, null), []),
+      ["DD_ENV"]
+    ))
+    connection_string_names = try(var.sticky_settings.connection_string_names, null)
+  } : var.sticky_settings
 }
 
 resource "azapi_resource" "datadog_sidecar" {

--- a/modules/linux/resource_impl.tf
+++ b/modules/linux/resource_impl.tf
@@ -390,10 +390,10 @@ resource "azurerm_linux_web_app" "this" {
     }
   }
   dynamic "sticky_settings" {
-    for_each = try(var.sticky_settings, null) != null ? [true] : []
+    for_each = local.sticky_settings != null ? [true] : []
     content {
-      app_setting_names       = try(var.sticky_settings.app_setting_names, null)
-      connection_string_names = try(var.sticky_settings.connection_string_names, null)
+      app_setting_names       = try(local.sticky_settings.app_setting_names, null)
+      connection_string_names = try(local.sticky_settings.connection_string_names, null)
     }
   }
   dynamic "storage_account" {

--- a/modules/windows/autogen_config.json
+++ b/modules/windows/autogen_config.json
@@ -6,7 +6,8 @@
     "fields": {
         "impl": [
             "app_settings",
-            "tags"
+            "tags",
+            "sticky_settings"
         ],
         "always_allow": [
             "site_config.application_stack.current_stack",

--- a/modules/windows/main.tf
+++ b/modules/windows/main.tf
@@ -24,6 +24,13 @@ locals {
     var.datadog_version != null ? { version = var.datadog_version } : {},
     var.tags
   )
+  sticky_settings = var.datadog_env != null ? {
+    app_setting_names = distinct(concat(
+      coalesce(try(var.sticky_settings.app_setting_names, null), []),
+      ["DD_ENV"]
+    ))
+    connection_string_names = try(var.sticky_settings.connection_string_names, null)
+  } : var.sticky_settings
 
 }
 

--- a/modules/windows/resource_impl.tf
+++ b/modules/windows/resource_impl.tf
@@ -407,10 +407,10 @@ resource "azurerm_windows_web_app" "this" {
     }
   }
   dynamic "sticky_settings" {
-    for_each = try(var.sticky_settings, null) != null ? [true] : []
+    for_each = local.sticky_settings != null ? [true] : []
     content {
-      app_setting_names       = try(var.sticky_settings.app_setting_names, null)
-      connection_string_names = try(var.sticky_settings.connection_string_names, null)
+      app_setting_names       = try(local.sticky_settings.app_setting_names, null)
+      connection_string_names = try(local.sticky_settings.connection_string_names, null)
     }
   }
   dynamic "storage_account" {


### PR DESCRIPTION
### What does this PR do?

When `datadog_env` is set on the `linux` or `windows` parent app modules, `DD_ENV` is automatically added to `sticky_settings.app_setting_names`. This prevents `DD_ENV` from swapping when deployment slots are swapped -- ensuring the environment tag stays on the correct slot regardless of which code version is running.

Mirrors the behavior added to `datadog-ci` in `makeStickySlotEnvVars()`.

### Motivation

Without this, a slot swap would carry `DD_ENV=staging` to the production slot (or vice versa), causing telemetry to be tagged with the wrong environment.

### Describe how you validated your changes

- `terraform validate` passes for both `modules/linux` and `modules/windows`
- Behavior by case:
  - `datadog_env = null` (default): `local.sticky_settings = var.sticky_settings` -- no change, fully backwards-compatible
  - `datadog_env = "staging"`, no user sticky_settings: `local.sticky_settings = { app_setting_names = ["DD_ENV"], connection_string_names = null }`
  - `datadog_env = "staging"` + `sticky_settings = { app_setting_names = ["MY_SETTING"] }`: result is `{ app_setting_names = ["MY_SETTING", "DD_ENV"] }` (deduped via `distinct`)
  - `modules/linux-slot` and `modules/windows-slot` are untouched (sticky settings are a parent app property)
- Live integration test using the `linux-slot-node` example (main app `datadog_env = "prod"`, staging slot `datadog_env = "staging"`):
  - Confirmed `DD_ENV` present in `slotConfigNames` after deploy
  - Performed a slot swap -- `DD_ENV` remained `prod` on main and `staging` on the staging slot

### Additional Notes

`autogen_config.json` updated to add `sticky_settings` to `fields.impl` so future autogen runs produce the correct output.