### PR TITLE
chore: document and expose generated changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,0 @@
-outputs.tf linguist-generated=true
-resource_impl.tf linguist-generated=true
-resource_variables.tf linguist-generated=true
-autogen_config_schema.json linguist-generated=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+`tf-autogen` regenerates `linux`, `windows`, `linux-slot`, and `windows-slot`.
+Install it once: `pipx install -e ~/dd/serverless-ci/terraform-autogen/`.
+Never edit generated `versions.tf`, `autogen_config_schema.json`, `resource_impl.tf`, `resource_variables.tf`, or `outputs.tf`.
+Instead, customize `main.tf`, `variables.tf`, `module_version.tf`, and `autogen_config.json`.
+Each `fields.impl` path makes generated code use a matching `local`. Nested fields read from an implemented parent local; exact nested overrides use underscore-separated flat local names.
+After changing `autogen_config.json` or referenced `main.tf` locals, run `tf-autogen` in every affected `modules/<module>` directory and inspect the diff.
+Fix unexpected generated output in the handwritten inputs, never in generated files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
### What does this PR do?

- Documents the `tf-autogen` workflow and generated-file boundaries for coding agents.
- Expands generated files by default in GitHub diffs so regeneration changes are easier to review.

### Motivation

Generated changes were easy to overlook and could be edited without updating their handwritten inputs.

### Additional Notes

Removing the Linguist attributes means GitHub no longer classifies these files as generated, so we can see what actually changed and catch weird issues earlier
